### PR TITLE
Errors and Android

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -63,7 +63,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
     public static void onRequestPermissionsResult(int requestCode,
                                            String permissions[], int[] grantResults) {
         if (permissionsPromises.containsKey(requestCode)) {
-                // If request is cancelled, the result arrays are empty.
+            // If request is cancelled, the result arrays are empty.
             Promise permissionsPromise = permissionsPromises.get(requestCode);
             if (grantResults.length > 0
                     && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
@@ -71,11 +71,10 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
             } else if (grantResults.length > 0
                     && grantResults[0] == PackageManager.PERMISSION_DENIED) {
                 permissionsPromise.resolve("denied");
-            } else {
+            } else if (permissionsPromises.size() == 1) { // there should only be one
                 permissionsPromise.reject("permissions - unknown error", grantResults.length > 0 ? String.valueOf(grantResults[0]) : "Request was cancelled");
             }
             permissionsPromises.remove(requestCode);
-            return;
         }
     }
 

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -92,7 +92,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
     //endregion
 
     //region Event Accessors
-    public WritableMap addEvent(String title, ReadableMap details) {
+    public WritableMap addEvent(String title, ReadableMap details) throws ParseException {
         String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
         SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -117,10 +117,11 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
             java.util.Calendar startCal = java.util.Calendar.getInstance();
             try {
                 startCal.setTime(sdf.parse(details.getString("startDate")));
-                eventValues.put(CalendarContract.Events.DTSTART, startCal.getTimeInMillis());
             } catch (ParseException e) {
                 e.printStackTrace();
+                throw e;
             }
+            eventValues.put(CalendarContract.Events.DTSTART, startCal.getTimeInMillis());
         }
 
         if (details.hasKey("endDate")) {
@@ -129,6 +130,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
                 endCal.setTime(sdf.parse(details.getString("endDate")));
             } catch (ParseException e) {
                 e.printStackTrace();
+                throw e;
             }
             eventValues.put(CalendarContract.Events.DTEND, endCal.getTimeInMillis());
         }

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -48,19 +48,16 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
     //region Calendar Permissions
     private void requestCalendarReadWritePermission(final Promise promise)
     {
-        if  (ContextCompat.checkSelfPermission(reactContext, Manifest.permission.WRITE_CALENDAR)!= PackageManager.PERMISSION_GRANTED)
-        {
-            Activity currentActivity = getCurrentActivity();
-            if (currentActivity == null) {
-                promise.reject("E_ACTIVITY_DOES_NOT_EXIST", "Activity doesn't exist");
-                return;
-            }
-            PERMISSION_REQUEST_CODE++;
-            permissionsPromises.put(PERMISSION_REQUEST_CODE, promise);
-            ActivityCompat.requestPermissions(currentActivity,
-                    new String[]{ Manifest.permission.WRITE_CALENDAR },
-                    PERMISSION_REQUEST_CODE);
+        Activity currentActivity = getCurrentActivity();
+        if (currentActivity == null) {
+            promise.reject("E_ACTIVITY_DOES_NOT_EXIST", "Activity doesn't exist");
+            return;
         }
+        PERMISSION_REQUEST_CODE++;
+        permissionsPromises.put(PERMISSION_REQUEST_CODE, promise);
+        ActivityCompat.requestPermissions(currentActivity,
+                new String[]{ Manifest.permission.WRITE_CALENDAR },
+                PERMISSION_REQUEST_CODE);
     }
 
     public static void onRequestPermissionsResult(int requestCode,


### PR DESCRIPTION
In this PR:
1. In our project we had a problem that sometimes `requestCalendarPermissions` was called twice. This caused the first request to be cancelled, which resulted in 2 separate and unfortunate crashes. These changes should fix these crashes.

2. issue #25 - save event will now "throw" the parse exception, if it occurs. This will, hopefully, allow better understanding of the error. In these cases the promise will be rejected with the original exception message.