### PR TITLE
Add missing line "import com.calendarevents.CalendarEventsPackage;" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ project(':react-native-calendar-events').projectDir = new File(rootProject.proje
 
 - Edit your `MainApplication.java` to look like this:
 ```java
+import com.calendarevents.CalendarEventsPackage;
+
+...
 
   @Override
 	protected List<ReactPackage> getPackages() {


### PR DESCRIPTION
@wmcmahan I found that such line is missing, without it I receive the following error:

```
:app:compileDebugJavaWithJavac
/Users/tonatiuh/projects/peppaa/android/app/src/main/java/com/peppaa/MainApplication.java:33: error: cannot find symbol
            new CalendarEventsPackage()
                ^
  symbol: class CalendarEventsPackage
1 error
Incremental compilation of 1 classes completed in 0.142 secs.
:app:compileDebugJavaWithJavac FAILED

FAILURE: Build failed with an exception.
```

By including it in my project the app is compiled successfully. 

Thanks for this awesome module! :)