### PR TITLE
Fix some crashes

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -353,7 +353,7 @@ RCT_EXPORT_MODULE()
 
 - (NSMutableArray *)calendarSupportedAvailabilitiesFromMask:(EKCalendarEventAvailabilityMask)types
 {
-    NSMutableArray *availabilitiesStrings = @[].mutableCopy;
+    NSMutableArray *availabilitiesStrings = [[NSMutableArray alloc] init];
 
     if(types & EKCalendarEventAvailabilityBusy) [availabilitiesStrings addObject:@"busy"];
     if(types & EKCalendarEventAvailabilityFree) [availabilitiesStrings addObject:@"free"];
@@ -376,6 +376,8 @@ RCT_EXPORT_MODULE()
             return @"tentative";
         case EKEventAvailabilityUnavailable:
             return @"unavailable";
+        default:
+            return @"notSupported";
     }
 }
 


### PR DESCRIPTION
`@[].mutableCopy` crashes in iOS 8.1 simulator, replacing with `[[NSMutableArray alloc] init]` fixes the problem.

Also the event.availability value is 4294967295 (0xFFFFFFFF) instead of -1 in iOS 8.1 simulator 🙈