### PR TITLE
remove unused createJSModules

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEventsPackage.java
+++ b/android/src/main/java/com/calendarevents/CalendarEventsPackage.java
@@ -1,7 +1,6 @@
 package com.calendarevents;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;

--- a/android/src/main/java/com/calendarevents/CalendarEventsPackage.java
+++ b/android/src/main/java/com/calendarevents/CalendarEventsPackage.java
@@ -13,11 +13,6 @@ import java.util.List;
 public class CalendarEventsPackage implements ReactPackage {
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Removes unused createJSModules that causes app to break with RN 0.47+. See breaking change here: [https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8](url)