### PR TITLE
fix reminders not working on android

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -426,7 +426,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
             ReadableMap reminder = reminders.getMap(i);
             ReadableType type = reminder.getType("date");
             if (type == ReadableType.Number) {
-                int minutes = reminder.getInt("date");
+                int minutes = Math.abs(reminder.getInt("date"));
                 ContentValues reminderValues = new ContentValues();
 
                 reminderValues.put(CalendarContract.Reminders.EVENT_ID, eventID);


### PR DESCRIPTION
As mentioned here in this issue: https://github.com/wmcmahan/react-native-calendar-events/issues/112

It does fix the issue with reminders not saving in android.