### PR TITLE
add attendees to fetched event IOS

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -446,6 +446,7 @@ RCT_EXPORT_MODULE()
                                          _notes: @"",
                                          _url: @"",
                                          _alarms: [NSArray array],
+                                         _attendees: [NSArray array],
                                          _recurrence: @"",
                                          _recurrenceRule: @{
                                                  @"frequency": @"",
@@ -496,6 +497,32 @@ RCT_EXPORT_MODULE()
         [formedCalendarEvent setValue:event.location forKey:_location];
     }
 
+    if (event.attendees) {
+        NSMutableArray *attendees = [[NSMutableArray alloc] init];
+        for (EKParticipant *attendee in event.attendees) {
+            
+            NSMutableDictionary *descriptionData = [NSMutableDictionary dictionary];
+            for (NSString *pairString in [attendee.description componentsSeparatedByString:@";"])
+            {
+                NSArray *pair = [pairString componentsSeparatedByString:@"="];
+                if ( [pair count] != 2)
+                    continue;
+                [descriptionData setObject:[[pair objectAtIndex:1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] forKey:[[pair objectAtIndex:0]stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+            }
+            
+            NSMutableDictionary *formattedAttendee = [[NSMutableDictionary alloc] init];
+            NSString *name = [descriptionData valueForKey:@"name"];
+            NSString *email = [descriptionData valueForKey:@"email"];
+            NSString *phone = [descriptionData valueForKey:@"phone"];
+            
+            [formattedAttendee setValue:name forKey:@"name"];
+            [formattedAttendee setValue:email forKey:@"email"];
+            [formattedAttendee setValue:phone forKey:@"phone"];
+
+            [attendees addObject:formattedAttendee];
+        }
+        [formedCalendarEvent setValue:attendees forKey:_attendees];
+    }
     if (event.hasAlarms) {
         NSMutableArray *alarms = [[NSMutableArray alloc] init];
 

--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -515,10 +515,24 @@ RCT_EXPORT_MODULE()
             NSString *email = [descriptionData valueForKey:@"email"];
             NSString *phone = [descriptionData valueForKey:@"phone"];
             
-            [formattedAttendee setValue:name forKey:@"name"];
-            [formattedAttendee setValue:email forKey:@"email"];
-            [formattedAttendee setValue:phone forKey:@"phone"];
-
+            if(email && ![email isEqualToString:@"(null)"]) {
+                [formattedAttendee setValue:email forKey:@"email"];
+            }
+            else {
+                [formattedAttendee setValue:@"" forKey:@"email"];
+            }
+            if(phone && ![phone isEqualToString:@"(null)"]) {
+                [formattedAttendee setValue:phone forKey:@"phone"];
+            }
+            else {
+                [formattedAttendee setValue:@"" forKey:@"phone"];
+            }
+            if(name && ![name isEqualToString:@"(null)"]) {
+                [formattedAttendee setValue:name forKey:@"name"];
+            }
+            else {
+                [formattedAttendee setValue:@"" forKey:@"name"];
+            }
             [attendees addObject:formattedAttendee];
         }
         [formedCalendarEvent setValue:attendees forKey:_attendees];


### PR DESCRIPTION
I never write before on C or Objective-c. 

On my opinion construction as below:

 if(email && ![email isEqualToString:@"(null)"]) {
     [formattedAttendee setValue:email forKey:@"email"];
}
else {
     [formattedAttendee setValue:@"" forKey:@"email"];
}


should be replaced with function. But I have a hot phase of the project and there is no time to disassemble the Objective-c syntax better.