### PR TITLE
returns 'color' property for calendars

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -5,6 +5,7 @@
 
 @interface RNCalendarEvents ()
 @property (nonatomic, strong) EKEventStore *eventStore;
+@property (nonatomic) NSString *hexStringFromColor;
 @property (nonatomic) BOOL isAccessToEventStoreGranted;
 @end
 
@@ -26,6 +27,19 @@ static NSString *const _availability = @"availability";
 static NSString *const _attendees    = @"attendees";
 
 @implementation RNCalendarEvents
+
+- (NSString *)hexStringFromColor:(UIColor *)color {
+    const CGFloat *components = CGColorGetComponents(color.CGColor);
+
+    CGFloat r = components[0];
+    CGFloat g = components[1];
+    CGFloat b = components[2];
+
+    return [NSString stringWithFormat:@"#%02lX%02lX%02lX",
+            lroundf(r * 255),
+            lroundf(g * 255),
+            lroundf(b * 255)];
+}   
 
 @synthesize bridge = _bridge;
 
@@ -477,6 +491,7 @@ RCT_EXPORT_MODULE()
                                         @"source": event.calendar.source.title,
                                         @"allowsModifications": @(event.calendar.allowsContentModifications),
                                         @"allowedAvailabilities": [self calendarSupportedAvailabilitiesFromMask:event.calendar.supportedEventAvailabilities],
+                                        @"color": [self hexStringFromColor:[UIColor colorWithCGColor:event.calendar.CGColor]]
                                         }
                                forKey:@"calendar"];
     }
@@ -674,7 +689,8 @@ RCT_EXPORT_METHOD(findCalendars:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
                                         @"title": calendar.title ? calendar.title : @"",
                                         @"allowsModifications": @(calendar.allowsContentModifications),
                                         @"source": calendar.source.title,
-                                        @"allowedAvailabilities": [self calendarSupportedAvailabilitiesFromMask:calendar.supportedEventAvailabilities]
+                                        @"allowedAvailabilities": [self calendarSupportedAvailabilitiesFromMask:calendar.supportedEventAvailabilities],
+                                        @"color": [self hexStringFromColor:[UIColor colorWithCGColor:calendar.CGColor]]
                                         }];
         }
         resolve(eventCalendars);

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -109,7 +109,8 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
                 CalendarContract.Calendars.IS_PRIMARY,
                 CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
                 CalendarContract.Calendars.ALLOWED_AVAILABILITY,
-                CalendarContract.Calendars.ACCOUNT_TYPE
+                CalendarContract.Calendars.ACCOUNT_TYPE,
+                CalendarContract.Calendars.CALENDAR_COLOR
         }, null, null, null);
 
         return serializeEventCalendars(cursor);
@@ -129,7 +130,8 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
                 CalendarContract.Calendars.IS_PRIMARY,
                 CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
                 CalendarContract.Calendars.ALLOWED_AVAILABILITY,
-                CalendarContract.Calendars.ACCOUNT_TYPE
+                CalendarContract.Calendars.ACCOUNT_TYPE,
+                CalendarContract.Calendars.CALENDAR_COLOR
         }, null, null, null);
 
         if (cursor != null && cursor.moveToFirst()) {
@@ -930,6 +932,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
         calendar.putString("source", cursor.getString(2));
         calendar.putArray("allowedAvailabilities", calendarAllowedAvailabilitiesFromDBString(cursor.getString(5)));
         calendar.putString("type", cursor.getString(6));
+        calendar.putString("color", cursor.getString(7));
 
         if (cursor.getString(3) != null) {
             calendar.putBoolean("isPrimary", cursor.getString(3).equals("1"));

--- a/index.android.js
+++ b/index.android.js
@@ -15,15 +15,37 @@ export default {
   },
 
   async fetchAllEvents (startDate, endDate, calendars = []) {
-    return CalendarEvents.findAllEvents(startDate, endDate, calendars)
+    return CalendarEvents.findAllEvents(startDate, endDate, calendars).then(events => {
+      return events.map(e => {
+        if (e.calendar && e.calendar.color) {
+          let color = `#${(0xFFFFFF + parseInt(e.calendar.color)).toString(16)}`;
+          e.calendar.color = color;
+        }
+        return e;
+      });
+    })
   },
 
   async findCalendars () {
-    return CalendarEvents.findCalendars();
+    return CalendarEvents.findCalendars().then(calendars => {
+      return calendars.map(c => {
+        if (c.color) {
+          let color = `#${(0xFFFFFF + parseInt(c.color)).toString(16)}`;
+          c.color = color;
+        }
+        return c; 
+      });
+    });
   },
 
   async findEventById (id) {
-    return CalendarEvents.findById(id);
+    return CalendarEvents.findById(id).then(event => {
+      if (event.calendar && event.calendar.color) {
+        let color = `#${(0xFFFFFF + parseInt(c.color)).toString(16)}`;
+        event.calendar.color = color;
+      }
+      return event;
+    })
   },
 
   async saveEvent (title, details, options = {sync: false}) {


### PR DESCRIPTION
Includes the color property for calendar objects as an RRGGBB hex string. 

NOTE:  For Android, I would have preferred to convert the color to hex in `CalendarEvents.java` but lost patience working with java, so the conversion takes place in `index.android.js`.