### PR TITLE
Add iCal rrule to events properties (WIP)

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -23,6 +23,7 @@ static NSString *const _occurrenceDate = @"occurrenceDate";
 static NSString *const _isDetached = @"isDetached";
 static NSString *const _availability = @"availability";
 static NSString *const _attendees    = @"attendees";
+static NSString *const _rrule = @"rrule";
 
 @implementation RNCalendarEvents
 
@@ -431,6 +432,7 @@ RCT_EXPORT_MODULE()
                                                  @"endDate": @""
                                                  },
                                          _availability: @"",
+                                         _rrule: @"",
                                          };
 
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
@@ -583,6 +585,8 @@ RCT_EXPORT_MODULE()
 
     if (event.hasRecurrenceRules) {
         EKRecurrenceRule *rule = [event.recurrenceRules objectAtIndex:0];
+        NSString *rrule = [[rule description] componentsSeparatedByString:@" RRULE "][1];
+        [formedCalendarEvent setValue:rrule forKey:_rrule];
         NSString *frequencyType = [self nameMatchingFrequency:[rule frequency]];
         [formedCalendarEvent setValue:frequencyType forKey:_recurrence];
 

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -845,6 +845,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
         boolean allDay = false;
         String startDateUTC = "";
         String endDateUTC = "";
+        String rrule = "";
 
         if (cursor.getString(3) != null) {
             foundStartDate.setTimeInMillis(Long.parseLong(cursor.getString(3)));
@@ -861,8 +862,9 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
         }
 
         if (cursor.getString(7) != null) {
+            rrule = cursor.getString(7);
             WritableNativeMap recurrenceRule = new WritableNativeMap();
-            String[] recurrenceRules = cursor.getString(7).split(";");
+            String[] recurrenceRules = rrule.split(";");
             SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
 
             event.putString("recurrence", recurrenceRules[0].split("=")[1].toLowerCase());
@@ -902,6 +904,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
         event.putString("location", cursor.getString(6));
         event.putString("availability", availabilityStringMatchingConstant(cursor.getInt(9)));
         event.putArray("attendees", (WritableArray) findAttendeesByEventId(cursor.getString(0)));
+        event.putString("rrule", rrule);
 
         if (cursor.getInt(10) > 0) {
             event.putArray("alarms", findReminderByEventId(cursor.getString(0), Long.parseLong(cursor.getString(3))));


### PR DESCRIPTION
Hi,

I've stumbled upon a use case when working with recurring events where I would greatly benefit from being able to retrieve the event's [iCal RRULE](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) as a whole string instead of what is currently available (recurrence and reccurenceRule).

There are severals npm library that allows working with such string and it would greatly reduce the workload that is being done on the module side (parsing property into an Object when retrieving or saving an event).

This is still a work in progress but before working on what's left (saveEvent and README), I'd like to know how you feel avout moving away from what is currently being done with reccuring events in favor of this.