### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    api 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Upon building with compile instruction I would get the below warning:
> Configure project :react-native-calendar-events 
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

Switching from compile to api made the warning go away.