### PR TITLE
Fix find events 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "27.0.3"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    api 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -218,7 +218,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
         if (calendars.size() > 0) {
             String calendarQuery = "AND (";
             for (int i = 0; i < calendars.size(); i++) {
-                calendarQuery += CalendarContract.Instances.CALENDAR_ID + " = " + calendars.getString(i);
+                calendarQuery += CalendarContract.Instances.CALENDAR_ID + " = " + calendars.getMap(i).toString();
                 if (i != calendars.size() - 1) {
                     calendarQuery += " OR ";
                 }
@@ -246,6 +246,7 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
                 CalendarContract.Instances.DURATION,
                 CalendarContract.Instances.ORIGINAL_SYNC_ID,
         }, selection, null, null);
+                
 
         return serializeEvents(cursor);
     }

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -162,7 +162,9 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
                 CalendarContract.Attendees.ATTENDEE_EMAIL,
                 CalendarContract.Attendees.ATTENDEE_TYPE,
                 CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
-                CalendarContract.Attendees.ATTENDEE_STATUS
+                CalendarContract.Attendees.ATTENDEE_STATUS,
+                CalendarContract.Attendees.ATTENDEE_IDENTITY,
+                CalendarContract.Attendees.ATTENDEE_ID_NAMESPACE
         }, query, args, null);
 
         if (cursor != null && cursor.moveToFirst()) {
@@ -984,7 +986,11 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
 
             attendee.putString("name", cursor.getString( 2));
             attendee.putString("email", cursor.getString(3));
-
+            attendee.putString("type", cursor.getString(4));
+            attendee.putString("relationship", cursor.getString(5));
+            attendee.putString("status", cursor.getString(6));
+            attendee.putString("identity", cursor.getString(7));
+            attendee.putString("id_namespace", cursor.getString(8));
             results.pushMap(attendee);
         }
 


### PR DESCRIPTION
Hi, please evaluate the following proposal.
The calendars.getMap(i).toString() was really the reason I could not use this lib.
The others are just a proposal update, I am planning on adding extraproperties support but I would like to close this one first and get you opinion.

Thanks for the brilliant  work.

Add new fields to attendee
            attendee.putString("type", cursor.getString(4));
            attendee.putString("relationship", cursor.getString(5));
            attendee.putString("status", cursor.getString(6));
            attendee.putString("identity", cursor.getString(7));
            attendee.putString("id_namespace", cursor.getString(8));
MinSDK to 16
Use calendars.getMap(i).toString(); as  calendars.getString(i); was giving me errors