### PR TITLE
Add the sageExtGet function to adapt custom version of buildTools, compileSdk and targetSdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,21 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
-
     }
     lintOptions {
-       warning 'InvalidPackage'
+        abortOnError false
     }
 }
 


### PR DESCRIPTION
Add the sageExtGet function to adapt custom version of buildTools, compileSdk and targetSdk