### PR TITLE
android: use PermissionListener to avoid Android manual steps

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEventsPackage.java
+++ b/android/src/main/java/com/calendarevents/CalendarEventsPackage.java
@@ -25,8 +25,4 @@ public class CalendarEventsPackage implements ReactPackage {
 
         return modules;
     }
-
-    public static void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        CalendarEvents.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
 }


### PR DESCRIPTION
When / if this lands, the last part of the wiki needs to be removed / clarified, since it'll be no longer needed: https://github.com/wmcmahan/react-native-calendar-events/wiki/Android-setup