### PR TITLE
added optional parameter to skip steps on android event fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Arguments:
  - startDate: Date - The start date of the range of events fetched.
  - endDate: Date - The end date of the range of events fetched.
  - calendars: Array - List of calendar id strings to specify calendar events. Defaults to all calendars if empty.
+ - androidLite: Bool - Large queries may take a long time to complete on Android devices - [#237](https://github.com/wmcmahan/react-native-calendar-events/issues/237). This option will speed up the query, but will return events *without* `attendees` and `calendar` props for Android. Defaults to false.
 
 Returns: **Promise**  
  - fulfilled: Array - Matched events within the specified date range.
@@ -213,7 +214,7 @@ Returns: **Promise**
 | Property        | Type            | Description | iOS | Android |
 | :--------------- | :---------------- | :----------- | :-----------: | :-----------: |
 | **id***  | String  | Unique id for the calendar event. | ✓ | ✓ |
-| **calendarId****   | String           | Unique id for the calendar where the event will be saved. Defaults to the device's default calendar. | ✓ | ✓ |
+| **calendarId**     | String           | Unique id for the calendar where the event will be saved. Defaults to the device's default calendar. | ✓ | ✓ |
 | **title**           | String           | The title for the calendar event. | ✓ | ✓ |
 | **startDate**       | Date             | The start date of the calendar event in ISO format. | ✓ | ✓ |
 | **endDate**         | Date             | The end date of the calendar event in ISO format. | ✓ | ✓ |

--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -493,6 +493,7 @@ RCT_EXPORT_MODULE()
     }
 
     if (event.calendar) {
+        [formedCalendarEvent setValue:event.calendar.calendarIdentifier forKey:@"calendarId"];
         [formedCalendarEvent setValue:@{
                                         @"id": event.calendar.calendarIdentifier,
                                         @"title": event.calendar.title ? event.calendar.title : @"",

--- a/index.android.js
+++ b/index.android.js
@@ -14,8 +14,8 @@ export default {
     return CalendarEvents.requestCalendarPermissions()
   },
 
-  async fetchAllEvents (startDate, endDate, calendars = []) {
-    return CalendarEvents.findAllEvents(startDate, endDate, calendars)
+  async fetchAllEvents (startDate, endDate, calendars = [], androidLite = false) {
+    return CalendarEvents.findAllEvents(startDate, endDate, calendars, androidLite)
   },
 
   async findCalendars () {

--- a/index.d.ts
+++ b/index.d.ts
@@ -189,7 +189,8 @@ export default class ReactNativeCalendarEvents {
   static fetchAllEvents(
     startDate: ISODateString,
     endDate: ISODateString,
-    calendarIds?: string[]
+    calendarIds?: string[],
+    androidLite?: boolean
   ): Promise<CalendarEventReadable[]>;
   /**
    * Creates or updates a calendar event. To update an event, the event id must be defined.

--- a/index.ios.js
+++ b/index.ios.js
@@ -15,7 +15,7 @@ export default {
   },
 
   fetchAllEvents (startDate, endDate, calendars = []) {
-    return RNCalendarEvents.fetchAllEvents(startDate, endDate, calendars, false)
+    return RNCalendarEvents.fetchAllEvents(startDate, endDate, calendars)
   },
 
   findCalendars () {

--- a/index.ios.js
+++ b/index.ios.js
@@ -15,7 +15,7 @@ export default {
   },
 
   fetchAllEvents (startDate, endDate, calendars = []) {
-    return RNCalendarEvents.fetchAllEvents(startDate, endDate, calendars)
+    return RNCalendarEvents.fetchAllEvents(startDate, endDate, calendars, false)
   },
 
   findCalendars () {


### PR DESCRIPTION
Fetching many events on android can be very slow as stated here - https://github.com/wmcmahan/react-native-calendar-events/issues/237
I was able to reduce my queries (about 1000 events) from 22s to 3s by removing  additional calls to attendees and calendar tables. I have added that behavior as an optional parameter.
I don't think this is the ideal solution, but it is a solution and it's backwards compatible, so I see no harm in sharing it ;)