### PR TITLE
android: fix parsing allowed availability

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
 import android.Manifest;
-import android.database.DatabaseUtils;
 import android.net.Uri;
 import android.provider.CalendarContract;
 import android.support.v4.app.ActivityCompat;
@@ -868,8 +867,23 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
     //region Availability
     private WritableNativeArray calendarAllowedAvailabilitiesFromDBString(String dbString) {
         WritableNativeArray availabilitiesStrings = new WritableNativeArray();
-        for(String availabilityId: dbString.split(",")) {
-            switch(Integer.parseInt(availabilityId)) {
+        for(String availabilityStr: dbString.split(",")) {
+            int availabilityId = -1;
+
+            try {
+                availabilityId = Integer.parseInt(availabilityStr);
+            } catch(NumberFormatException e) {
+                // Some devices seem to just use strings.
+                if (availabilityStr.equals("AVAILABILITY_BUSY")) {
+                    availabilityId = CalendarContract.Events.AVAILABILITY_BUSY;
+                } else if (availabilityStr.equals("AVAILABILITY_FREE")) {
+                    availabilityId = CalendarContract.Events.AVAILABILITY_FREE;
+                } else if (availabilityStr.equals("AVAILABILITY_TENTATIVE")) {
+                    availabilityId = CalendarContract.Events.AVAILABILITY_TENTATIVE;
+                }
+            }
+
+            switch(availabilityId) {
                 case CalendarContract.Events.AVAILABILITY_BUSY:
                     availabilitiesStrings.pushString("busy");
                     break;


### PR DESCRIPTION
Some devices (notably Samsungs running Android 8 and 6) use strings
instead of the actual constants.

Sample backtrace:

```
Fatal Exception: java.lang.NumberFormatException: Invalid int: "AVAILABILITY_BUSY"
       at java.lang.Integer.invalidInt + 138(Integer.java:138)
       at java.lang.Integer.parse + 410(Integer.java:410)
       at java.lang.Integer.parseInt + 367(Integer.java:367)
       at java.lang.Integer.parseInt + 334(Integer.java:334)
       at com.calendarevents.CalendarEvents.calendarAllowedAvailabilitiesFromDBString + 749(CalendarEvents.java:749)
```