### PR TITLE
Added key to skip setting timezone on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Returns: **Promise**
 | [**alarms**](#alarms)          | Array            | The alarms associated with the calendar event, as an array of alarm objects. | ✓ | ✓ |
 | [**attendees**](#attendees)*   | Array            | The attendees of the event, including the organizer. | ✓ | ✓ |
 | [**calendar**](#calendar)*    | Object      | The calendar containing the event.| ✓ | ✓ |
+| **skipAndroidTimezone**    | Bool      | Skip the process of setting automatic timezone on android|  | ✓ |
 
 
 ### Calendar

--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -425,8 +425,13 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
     private int addEvent(String title, ReadableMap details, ReadableMap options) throws ParseException {
         String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
         SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-
+        boolean skipTimezone = false;
+        if(details.hasKey("skipAndroidTimezone") && details.getBoolean("skipAndroidTimezone")){
+            skipTimezone = true;
+        }
+        if(!skipTimezone){
+            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+        }
         ContentResolver cr = reactContext.getContentResolver();
         ContentValues eventValues = new ContentValues();
 


### PR DESCRIPTION
When using the format `YYYY-MM-DDTHH:mm:ss.SSSZ` it works fine on ios but on android it gives the following error:
`Unparseable date: "2019-08-22T15:00:00.000-05:00"`

To fix this, people use the format `YYYY-MM-DDTHH:mm:ss.SSS[Z]` which gives `2019-08-22T15:00:00.000Z` and works fine.

The problem is that since I am in a different timezone (GTM-5) that part gets lost when using the latter time format and the event is added 5 hours earlier than the actual time passed.

This PR adds the ability to skip setting the time format on the native side by setting `skipAndroidTimezone: true` in the details passed to `saveEvent`.

Ideally the library should accept the format `YYYY-MM-DDTHH:mm:ss.SSSZ`so the timezone part doesn't get lost.

This probably fixes #229 and #232 which are closed but I didn't find my answer there