### PR TITLE
"NEVER ASK ME AGAIN" status added in android

### DIFF
--- a/android/src/main/java/com/calendarevents/CalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/CalendarEvents.java
@@ -98,6 +98,16 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
         return writePermission == PackageManager.PERMISSION_GRANTED &&
                 readPermission == PackageManager.PERMISSION_GRANTED;
     }
+    
+    private boolean shouldShowRequestPermissionRationale() {
+                Activity currentActivity = getCurrentActivity();
+
+        boolean permission = ActivityCompat.shouldShowRequestPermissionRationale(currentActivity,
+                    Manifest.permission.WRITE_CALENDAR);
+
+        return permission;
+    }
+
     //endregion
 
     private WritableNativeArray findEventCalendars() {
@@ -1150,8 +1160,10 @@ public class CalendarEvents extends ReactContextBaseJavaModule {
             promise.resolve("authorized");
         } else if (!permissionRequested) {
             promise.resolve("undetermined");
+        } else if(this.shouldShowRequestPermissionRationale()) {
+            promise.resolve("denied"); 
         } else {
-            promise.resolve("denied");
+            promise.resolve("restricted");
         }
     }
 


### PR DESCRIPTION
```RNCalendarEvents.authorizationStatus()``` used to  return "denied" even if the user denied it with selecting the "Never ask me again" checkbox before. It wasn't returning "restricted" as expected.

Added a rationale check to verify if the user has selected "Never ask me again" so it will now return "restricted".