### PR TITLE
fix iOS 13 show bug

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -173,7 +173,7 @@ RCT_EXPORT_MODULE()
         calendarEvent.availability = [self availablilityConstantMatchingString:availability];
     }
 
-    NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
+    NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
     if (URL) {
         calendarEvent.URL = URL;
     }

--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -173,11 +173,9 @@ RCT_EXPORT_MODULE()
         calendarEvent.availability = [self availablilityConstantMatchingString:availability];
     }
 
-    NSURL *URL;
-    if (@available(iOS 13.0, *)) {
-        URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-    } else {
-        URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
+    NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+    if (URL) {
+        calendarEvent.URL = URL;
     }
 
     if ([details objectForKey:@"structuredLocation"] && [[details objectForKey:@"structuredLocation"] count]) {

--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -173,9 +173,11 @@ RCT_EXPORT_MODULE()
         calendarEvent.availability = [self availablilityConstantMatchingString:availability];
     }
 
-    NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-    if (URL) {
-        calendarEvent.URL = URL;
+    NSURL *URL;
+    if (@available(iOS 13.0, *)) {
+        URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+    } else {
+        URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
     }
 
     if ([details objectForKey:@"structuredLocation"] && [[details objectForKey:@"structuredLocation"] count]) {


### PR DESCRIPTION
on iOS 13 version, when i do saveEvent, the url params show in a error。for example:
the url's value `http://www.baidu.com` will show `http:%3A%2F%2Fwww.baidu.com`。

#272 