### PR TITLE
Adding iOS eventIdentifier

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -533,6 +533,7 @@ RCT_EXPORT_MODULE()
     if (event.attendees) {
         
         NSString *orgemail = @"";
+        NSString *orgphone = @"";
         
         if(event.organizer) {
         
@@ -550,10 +551,12 @@ RCT_EXPORT_MODULE()
                    }
         
         orgemail = [descriptionDataOrganizer valueForKey:@"email"];
-       }
+        orgphone = [descriptionDataOrganizer valueForKey:@"phone"];
+        }
         
         NSMutableArray *attendees = [[NSMutableArray alloc] init];
         
+        Boolean organizerFound = NO;
         for (EKParticipant *attendee in event.attendees) {
             
             NSMutableDictionary *descriptionData = [NSMutableDictionary dictionary];
@@ -593,6 +596,7 @@ RCT_EXPORT_MODULE()
             }
             if(relationship && ![relationship isEqualToString:@"(null)"]) {
                 if([orgemail isEqualToString:email]){
+                    organizerFound = YES;
                     [formattedAttendee setValue:@"2" forKey:@"relationship"];
                 }else {
                     [formattedAttendee setValue:relationship forKey:@"relationship"];
@@ -616,6 +620,27 @@ RCT_EXPORT_MODULE()
             
             [attendees addObject:formattedAttendee];
         }
+        
+        if (!organizerFound) {
+            NSString *status = [NSString stringWithFormat: @"%ld", (long)event.organizer.participantStatus];
+            NSString *type = [NSString stringWithFormat: @"%ld", (long)event.organizer.participantType];
+            
+            NSMutableDictionary *formattedOrganizer = [[NSMutableDictionary alloc] init];
+            [formattedOrganizer setValue:orgemail forKey:@"email"];
+            [formattedOrganizer setValue:@"2" forKey:@"relationship"];
+            if(orgphone && ![orgphone isEqualToString:@"(null)"]) {
+                [formattedOrganizer setValue:orgphone forKey:@"phone"];
+            }
+            else {
+                [formattedOrganizer setValue:@"" forKey:@"phone"];
+            }
+            [formattedOrganizer setValue:status forKey:@"status"];
+            [formattedOrganizer setValue:type forKey:@"type"];
+            [formattedOrganizer setValue:event.organizer.name forKey:@"name"];
+
+            [attendees addObject:formattedOrganizer];
+        }
+
         [formedCalendarEvent setValue:attendees forKey:_attendees];
     }
     if (event.hasAlarms) {

--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -524,15 +524,38 @@ RCT_EXPORT_MODULE()
     if (event.URL) {
         [formedCalendarEvent setValue:[event.URL absoluteString] forKey:_url];
     }
+    
 
     if (event.location) {
         [formedCalendarEvent setValue:event.location forKey:_location];
     }
 
     if (event.attendees) {
-        NSMutableArray *attendees = [[NSMutableArray alloc] init];
-        for (EKParticipant *attendee in event.attendees) {
+        
+        NSString *orgemail = @"";
+        
+        if(event.organizer) {
+        
+        EKParticipant *organizer = event.organizer;
 
+        NSString *organizerDescription = [organizer description];
+        
+         NSMutableDictionary *descriptionDataOrganizer = [NSMutableDictionary dictionary];
+                   for (NSString *pairString in [organizerDescription componentsSeparatedByString:@";"])
+                   {
+                       NSArray *pairorg = [pairString componentsSeparatedByString:@"="];
+                       if ( [pairorg count] != 2)
+                           continue;
+                       [descriptionDataOrganizer setObject:[[pairorg objectAtIndex:1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] forKey:[[pairorg objectAtIndex:0]stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+                   }
+        
+        orgemail = [descriptionDataOrganizer valueForKey:@"email"];
+       }
+        
+        NSMutableArray *attendees = [[NSMutableArray alloc] init];
+        
+        for (EKParticipant *attendee in event.attendees) {
+            
             NSMutableDictionary *descriptionData = [NSMutableDictionary dictionary];
             for (NSString *pairString in [attendee.description componentsSeparatedByString:@";"])
             {
@@ -546,6 +569,9 @@ RCT_EXPORT_MODULE()
             NSString *name = [descriptionData valueForKey:@"name"];
             NSString *email = [descriptionData valueForKey:@"email"];
             NSString *phone = [descriptionData valueForKey:@"phone"];
+            NSString *relationship = [NSString stringWithFormat: @"%ld", (long)attendee.participantRole] ;
+            NSString *status = [NSString stringWithFormat: @"%ld", (long)attendee.participantStatus];
+            NSString *type = [NSString stringWithFormat: @"%ld", (long)attendee.participantType];
 
             if(email && ![email isEqualToString:@"(null)"]) {
                 [formattedAttendee setValue:email forKey:@"email"];
@@ -565,6 +591,29 @@ RCT_EXPORT_MODULE()
             else {
                 [formattedAttendee setValue:@"" forKey:@"name"];
             }
+            if(relationship && ![relationship isEqualToString:@"(null)"]) {
+                if([orgemail isEqualToString:email]){
+                    [formattedAttendee setValue:@"2" forKey:@"relationship"];
+                }else {
+                    [formattedAttendee setValue:relationship forKey:@"relationship"];
+                }
+            }
+            else {
+                [formattedAttendee setValue:@"" forKey:@"relationship"];
+            }
+            if(status && ![status isEqualToString:@"(null)"]) {
+                [formattedAttendee setValue:status forKey:@"status"];
+            }
+            else {
+                [formattedAttendee setValue:@"" forKey:@"status"];
+            }
+            if(type && ![type isEqualToString:@"(null)"]) {
+                [formattedAttendee setValue:type forKey:@"type"];
+            }
+            else {
+                [formattedAttendee setValue:@"" forKey:@"type"];
+            }
+            
             [attendees addObject:formattedAttendee];
         }
         [formedCalendarEvent setValue:attendees forKey:_attendees];

--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -8,6 +8,7 @@
 @end
 
 static NSString *const _id = @"id";
+static NSString *const _eventIdentifier = @"eventIdentifier";
 static NSString *const _calendarId = @"calendarId";
 static NSString *const _title = @"title";
 static NSString *const _location = @"location";
@@ -469,6 +470,7 @@ RCT_EXPORT_MODULE()
 {
 
     NSDictionary *emptyCalendarEvent = @{
+                                         _eventIdentifier: @"",
                                          _title: @"",
                                          _location: @"",
                                          _startDate: @"",
@@ -511,6 +513,10 @@ RCT_EXPORT_MODULE()
                                         @"color": [self hexStringFromColor:[UIColor colorWithCGColor:event.calendar.CGColor]]
                                         }
                                forKey:@"calendar"];
+    }
+
+    if (event.eventIdentifier) {
+      [formedCalendarEvent setValue:event.eventIdentifier forKey:_eventIdentifier];
     }
 
     if (event.title) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,8 @@ interface CalendarEventBase {
 export interface CalendarEventReadable extends CalendarEventBase {
   /** Unique id for the calendar event */
   id: string;
+  /** iOS ONLY - iOS's own unique identifier for calendar events */
+  eventIdentifier?: string;
   /** The title for the calendar event. */
   title: string;
   /** The attendees of the event, including the organizer. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,6 +110,8 @@ export interface CalendarEventReadable extends CalendarEventBase {
   occurrenceDate?: ISODateString;
   /** The alarms associated with the calendar event, as an array of alarm objects. */
   alarms?: Array<Alarm<ISODateString>>;
+  /** Added by devang patel for calander event requirements */
+  priority?: string;
 }
 
 export interface CalendarEventWritable extends CalendarEventBase {

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,8 +110,8 @@ export interface CalendarEventReadable extends CalendarEventBase {
   occurrenceDate?: ISODateString;
   /** The alarms associated with the calendar event, as an array of alarm objects. */
   alarms?: Array<Alarm<ISODateString>>;
-  /** Added by devang patel for calander event requirements */
-  priority?: string;
+   /** Added by devang patel for calander event requirements */
+  isPriority?: boolean;
 }
 
 export interface CalendarEventWritable extends CalendarEventBase {


### PR DESCRIPTION
Add `eventIdentifier` property for iOS events. This identifier is used to show and edit existing iOS calendar events.