### PR TITLE
Avoid iOS crash at all cost

### DIFF
--- a/ios/RNCalendarEvents.m
+++ b/ios/RNCalendarEvents.m
@@ -587,7 +587,7 @@ RCT_EXPORT_MODULE()
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"RNCalendarEvents encountered an issue will serializing event (attendees) '%@': %@", event.title, exception.reason);
+        NSLog(@"RNCalendarEvents encountered an issue while serializing event (attendees) '%@': %@", event.title, exception.reason);
     }
     
     @try {
@@ -648,7 +648,7 @@ RCT_EXPORT_MODULE()
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"RNCalendarEvents encountered an issue will serializing event (alarms) '%@': %@", event.title, exception.reason);
+        NSLog(@"RNCalendarEvents encountered an issue while serializing event (alarms) '%@': %@", event.title, exception.reason);
     }
 
     if (event.startDate) {
@@ -691,7 +691,7 @@ RCT_EXPORT_MODULE()
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"RNCalendarEvents encountered an issue will serializing event (recurrenceRules) '%@': %@", event.title, exception.reason);
+        NSLog(@"RNCalendarEvents encountered an issue while serializing event (recurrenceRules) '%@': %@", event.title, exception.reason);
     }
     
     [formedCalendarEvent setValue:[self availabilityStringMatchingConstant:event.availability] forKey:_availability];
@@ -714,7 +714,7 @@ RCT_EXPORT_MODULE()
         }
     }
     @catch (NSException *exception) {
-        NSLog(@"RNCalendarEvents encountered an issue will serializing event (structuredLocation) '%@': %@", event.title, exception.reason);
+        NSLog(@"RNCalendarEvents encountered an issue while serializing event (structuredLocation) '%@': %@", event.title, exception.reason);
     }
 
     return [formedCalendarEvent copy];


### PR DESCRIPTION
This allow to skip some part of events (during serialization) that leave an NSLog and also add try/catch with reject for most method that present a risk.
This helped me recover errors from JavaScript instead of facing a brutal crash.

@wmcmahan I am very new to objective-c & would like your input on this (asking since I saw you handled some issues yay!)

[**Better to review without whitespace changes!**](https://github.com/wmcmahan/react-native-calendar-events/pull/314/files?diff=unified&w=1)

Note that this PR is on branch 2.0.0 (I am preparing a release with latest changes that are in master, unreleased, and some others that I tried on the 2.0.0 branch)

Also, should we do something similar for Android or is the way async is handled (from JS) enough to trigger promise rejection if something fails native side?)

Closes #311
Closes #281