### PR TITLE
declare requestPermissions in typescript def

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -168,7 +168,7 @@ export default class ReactNativeCalendarEvents {
   /** Get calendar authorization status. */
   static checkPermissions(): Promise<AuthorizationStatus>;
   /** Request calendar authorization. Authorization must be granted before accessing calendar events. */
-  static checkPermissions(): Promise<AuthorizationStatus>;
+  static requestPermissions(): Promise<AuthorizationStatus>;
 
   /** Finds all the calendars on the device. */
   static findCalendars(): Promise<Calendar[]>;


### PR DESCRIPTION
Small fix to replace duplicate `checkPermissions` Typescript definition with `requestPermissions`.

Issue: #315 