### PR TITLE
Add Android read only option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `react-native-calendar-events`
 
-## 2.1.0 - 2020-08-10
+## Unreleased
 
 - Added ability to restrict to read-only permission on Android [#320](https://github.com/wmcmahan/react-native-calendar-events/pull/320) by [@mikehardy](https://github.com/mikehardy)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `react-native-calendar-events`
 
+## 2.1.0 - 2020-08-10
+
+- Added ability to restrict to read-only permission on Android [#320](https://github.com/wmcmahan/react-native-calendar-events/pull/320) by [@mikehardy](https://github.com/mikehardy)
+
 ## 2.0.1 - 2020-08-01
 
 - Fixed TypeScript definition for missing `requestPermissions` [#316](https://github.com/wmcmahan/react-native-calendar-events/pull/316) by [@wmcmahan](https://github.com/wmcmahan)

--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ import RNCalendarEvents from "react-native-calendar-events";
 ### `checkPermissions`
 
 Get calendar authorization status.
+You may check for the default read/write access with no argument, or read-only access on Android by passing boolean true. iOS is always read/write.
 
 ```javascript
-RNCalendarEvents.checkPermissions();
+RNCalendarEvents.checkPermissions((readOnly = false));
 ```
 
 Returns: **Promise**
@@ -127,8 +128,20 @@ Returns: **Promise**
 
 Request calendar authorization. Authorization must be granted before accessing calendar events.
 
+Note that to restrict to read-only usage on Android (iOS is always read/write) you will need to alter the included Android permissions
+as the AndroidManifest.xml is merged during the Android build.
+
+You do that by altering your AndroidManifest.xml to "remove" the WRITE_CALENDAR permission with an entry like so:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  >
+  <uses-permission tools:node="remove" android:name="android.permission.WRITE_CALENDAR" />
+```
+
 ```javascript
-RNCalendarEvents.requestPermissions();
+RNCalendarEvents.requestPermissions((readOnly = false));
 ```
 
 > Android note: This is necessary for targeted SDK of >=23.

--- a/example/App.js
+++ b/example/App.js
@@ -13,6 +13,7 @@ import {
   StatusBar,
   Button,
   Alert,
+  Platform,
 } from 'react-native';
 import {Header, Colors} from 'react-native/Libraries/NewAppScreen';
 import RNCalendarEvents from 'react-native-calendar-events';
@@ -33,7 +34,7 @@ const App: () => React$Node = () => {
           )}
           <View style={styles.body}>
             <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Auth</Text>
+              <Text style={styles.sectionTitle}>Read/Write Auth</Text>
               <Text style={styles.sectionDescription}>
                 <Button
                   title="Request auth"
@@ -64,6 +65,40 @@ const App: () => React$Node = () => {
                 />
               </Text>
             </View>
+            {Platform.OS === 'android' && (
+              <View style={styles.sectionContainer}>
+                <Text style={styles.sectionTitle}>Read-Only Auth</Text>
+                <Text style={styles.sectionDescription}>
+                  <Button
+                    title="Request auth"
+                    onPress={() => {
+                      RNCalendarEvents.requestPermissions(true).then(
+                        (result) => {
+                          Alert.alert('Read-only Auth requested', result);
+                        },
+                        (result) => {
+                          console.error(result);
+                        },
+                      );
+                    }}
+                  />
+                  <Text>{'\n'}</Text>
+                  <Button
+                    title="Check auth"
+                    onPress={() => {
+                      RNCalendarEvents.checkPermissions(true).then(
+                        (result) => {
+                          Alert.alert('Read-only Auth check', result);
+                        },
+                        (result) => {
+                          console.error(result);
+                        },
+                      );
+                    }}
+                  />
+                </Text>
+              </View>
+            )}
             <View style={styles.sectionContainer}>
               <Text style={styles.sectionTitle}>Calendars</Text>
               <Text style={styles.sectionDescription}>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -296,7 +296,7 @@ PODS:
     - React-Core (= 0.63.2)
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
-  - RNCalendarEvents (2.0.0):
+  - RNCalendarEvents (2.0.1):
     - React
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -460,7 +460,7 @@ SPEC CHECKSUMS:
   React-RCTText: 1b6773e776e4b33f90468c20fe3b16ca3e224bb8
   React-RCTVibration: 4d2e726957f4087449739b595f107c0d4b6c2d2d
   ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
-  RNCalendarEvents: c2c2e113f384bd193886bd529cf91f836b9e5888
+  RNCalendarEvents: d2029b1ec739b5ffc379bf72e597ec0b166bd8e6
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/package.json
+++ b/example/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "clean": "trash ./node_modules ./ios/Pods",
+    "clean": "rm -fr ./node_modules ./ios/Pods",
     "reinstall": "yarn clean && yarn",
     "ios:dependencies": "bundle install",
     "ios:dependencies:install": "cd ios && bundle exec pod install --repo-update",
-    "clean-modules": "trash ./node_modules/react-native-calendar-events/{example,node_modules}",
+    "clean-modules": "rm -fr ./node_modules/react-native-calendar-events/{example,node_modules}",
     "prepare": "yarn clean-modules && yarn ios:dependencies && yarn ios:dependencies:install",
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/src/index.android.js
+++ b/src/index.android.js
@@ -3,11 +3,11 @@ import { NativeModules, processColor } from "react-native";
 const RNCalendarEvents = NativeModules.RNCalendarEvents;
 
 export default {
-  async checkPermissions() {
-    return RNCalendarEvents.checkPermissions();
+  async checkPermissions(readOnly = false) {
+    return RNCalendarEvents.checkPermissions(readOnly);
   },
-  async requestPermissions() {
-    return RNCalendarEvents.requestPermissions();
+  async requestPermissions(readOnly = false) {
+    return RNCalendarEvents.requestPermissions(readOnly);
   },
 
   async fetchAllEvents(startDate, endDate, calendars = []) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -165,10 +165,16 @@ export type CalendarAccountSourceAndroid =
     };
 
 export default class ReactNativeCalendarEvents {
-  /** Get calendar authorization status. */
-  static checkPermissions(): Promise<AuthorizationStatus>;
-  /** Request calendar authorization. Authorization must be granted before accessing calendar events. */
-  static requestPermissions(): Promise<AuthorizationStatus>;
+  /**
+   * Get calendar authorization status.
+   * @param readOnly - optional, default false, use true to check for calendar read only vs calendar read/write. Android-specific, iOS is always read/write
+   */
+  static checkPermissions(readOnly?: boolean): Promise<AuthorizationStatus>;
+  /**
+   * Request calendar authorization. Authorization must be granted before accessing calendar events.
+   * @param readOnly - optional, default false, use true to check for calendar read only vs calendar read/write. Android-specific, iOS is always read/write
+   */
+  static requestPermissions(readOnly?: boolean): Promise<AuthorizationStatus>;
 
   /** Finds all the calendars on the device. */
   static findCalendars(): Promise<Calendar[]>;

--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -3,10 +3,12 @@ import { NativeModules, processColor } from "react-native";
 const RNCalendarEvents = NativeModules.RNCalendarEvents;
 
 export default {
-  checkPermissions() {
+  checkPermissions(readOnly = false) {
+    // readOnly is ignored on iOS, the platform does not support it.
     return RNCalendarEvents.checkPermissions();
   },
-  requestPermissions() {
+  requestPermissions(readOnly = false) {
+    // readOnly is ignored on iOS, the platform does not support it.
     return RNCalendarEvents.requestPermissions();
   },
 


### PR DESCRIPTION

Hi there!

This adds the ability to specify a "readOnly" parameter for checkPermission / requestPermission for Android so that the WRITE_CALENDAR permission may be dropped from AndroidManifest.xml if a project desires

All behavior is intended to be backwards-compatible, including the SharedPreferences key used for permission check status

Documentation, example app, types, and even CHANGELOG updated

This seemed to work fine in my testing on the included example app *before* I altered it (as a backwards-compatibility check), and after I altered it with the new read-only block for android devices (as a test of new functionality)

I've been using the module like this in my project for more than a year, and I'll integrate this branch as well, for further testing

Let me know what you think! Cheers

Fixes #318 