### PR TITLE
include ts declaration in package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "calendar-events"
   ],
   "main": "src",
+  "types": "src/index.d.ts",
   "files": [
     "android/",
     "ios/",


### PR DESCRIPTION
Add TypeScript declarations to "types" in package file. Currently missing after v2.0.0 directory cleanup when the `index.d.ts` file was moved from the project root to `src/index.d.ts`