### PR TITLE
Change android calendar query to catch events that intersect date ran…

### DIFF
--- a/android/src/main/java/com/calendarevents/RNCalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/RNCalendarEvents.java
@@ -355,8 +355,8 @@ public class RNCalendarEvents extends ReactContextBaseJavaModule implements Perm
 
         Uri uri = uriBuilder.build();
 
-        String selection = "((" + CalendarContract.Instances.BEGIN + " >= " + eStartDate.getTimeInMillis() + ") " +
-                "AND (" + CalendarContract.Instances.END + " <= " + eEndDate.getTimeInMillis() + ") " +
+        String selection = "((" + CalendarContract.Instances.BEGIN + " < " + eEndDate.getTimeInMillis() + ") " +
+                "AND (" + CalendarContract.Instances.END + " >= " + eStartDate.getTimeInMillis() + ") " +
                 "AND (" + CalendarContract.Instances.VISIBLE + " = 1) " +
                 "AND (" + CalendarContract.Instances.STATUS + " IS NOT " + CalendarContract.Events.STATUS_CANCELED + ") ";
 


### PR DESCRIPTION
There's a difference between how iOS and Android fetchEvents.  Given start and end dates, iOS will gets the intersection of events for those dates whereas Android is getting a subset.

For example:
Start and end dates are 2020-11-25T08:00:00.000Z and 2020-11-25T09:00:00.000Z
The event we are expecting goes from 2020-11-25T08:30:00.000Z and 2020-11-25T09:30:00.000Z

The iOS version will return this event but the Android version won't.

So change the date filter to look for events that start before our end date and end after our start date