### PR TITLE
[iOS] Adds validation to prevent error on empty url

### DIFF
--- a/ios/RNCalendarEvents.m
+++ b/ios/RNCalendarEvents.m
@@ -196,9 +196,11 @@ RCT_EXPORT_MODULE()
         calendarEvent.availability = [self availablilityConstantMatchingString:availability];
     }
 
-    NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-    if (URL) {
-        calendarEvent.URL = URL;
+    if (![url isKindOfClass: [NSNull class]]) {
+        NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+        if (URL) {
+            calendarEvent.URL = URL;
+        }
     }
 
     if ([details objectForKey:@"structuredLocation"] && [[details objectForKey:@"structuredLocation"] count]) {


### PR DESCRIPTION
This bug currently exists on iOS only, tested on an iPhone 8 on OS version 14.4.

Currently, the details object is being brought as a dictionary and there is no validation on trying to use that to do additional operations. We've had a bug where if the `url` is NSNull (unspecified in JS), the library will throw a native exception and not add the event to the calendar.

This PR adds additional validation to make sure the url is not empty before trying to use it.