### PR TITLE
Make iOS edit the correct event in a recurring series when editing an event

### DIFF
--- a/ios/RNCalendarEvents.m
+++ b/ios/RNCalendarEvents.m
@@ -120,8 +120,25 @@ RCT_EXPORT_MODULE()
     NSString *timeZone = [RCTConvert NSString:details[_timeZone]];
 
     if (eventId) {
-        calendarEvent = (EKEvent *)[self.eventStore calendarItemWithIdentifier:eventId];
+        Boolean futureEvents = [RCTConvert BOOL:options[@"futureEvents"]];
+        NSDate *exceptionDate = [RCTConvert NSDate:options[@"exceptionDate"]];
 
+        if(exceptionDate) {
+            NSPredicate *predicate = [self.eventStore predicateForEventsWithStartDate:exceptionDate
+                                                                              endDate:endDate
+                                                                            calendars:nil];
+            NSArray *calendarEvents = [self.eventStore eventsMatchingPredicate:predicate];
+
+            for (EKEvent *event in calendarEvents) {
+                if ([event.calendarItemIdentifier isEqualToString:eventId] && [event.startDate isEqualToDate:exceptionDate]) {
+                    calendarEvent = event;
+                    break;
+                }
+            }
+        }
+        else {
+            calendarEvent = (EKEvent *)[self.eventStore calendarItemWithIdentifier:eventId];
+        }
     } else {
         calendarEvent = [EKEvent eventWithEventStore:self.eventStore];
         calendarEvent.calendar = [self.eventStore defaultCalendarForNewEvents];


### PR DESCRIPTION
iOS: Retrieve the desired event in a recurring series, rather than always getting the first event in the series.

This fix finds the exact occurrence of the series (in the same way as the delete event method does).