### PR TITLE
Added 'sync' param to Options typescript definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,6 +26,8 @@ export interface Options {
   exceptionDate?: ISODateString;
   /** iOS ONLY - If true the update will span all future events. If false it only update the single instance. */
   futureEvents?: boolean;
+  /** ANDROID ONLY - If true, can help avoid syncing issues */
+  sync?: boolean;
 }
 
 interface Alarm<D = ISODateString | number> {


### PR DESCRIPTION
Just wanted to add the "sync" param to the Options typescript definition file, which came out of this discussion:
https://github.com/wmcmahan/react-native-calendar-events/issues/362