### PR TITLE
fix: android phone need endDate when create a event

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -116,13 +116,16 @@ export interface CalendarEventReadable extends CalendarEventBase {
   alarms?: Array<Alarm<ISODateString>>;
 }
 
-export interface CalendarEventWritable extends CalendarEventBase {
+export interface CalendarEventWritable extends Omit<CalendarEventBase, 'endDate'> {
   /** Unique id for the calendar event, used for updating existing events */
   id?: string;
   /** The event's recurrence settings */
   recurrenceRule?: RecurrenceRule;
   /** The alarms associated with the calendar event, as an array of alarm objects. */
   alarms?: Array<Alarm<ISODateString | number>>;
+
+  /** if there is no end Date, android app will crash */
+  endDate: ISODateString;
 }
 
 export interface CalendarOptions {


### PR DESCRIPTION
When I ignore the param endDate for a event creating on Android, the thread will crash.
After I add this param endDate, it works well.

```
const updateResult = await NativeCalendar.saveEvent(tempEventTitle, {
  startDate: new Date().toISOString(),
  endDate: new Date('2021-08-01').toISOString(), // add this line then works well
  calendarId
})
```