### PR TITLE
Added CalendarEvent.structuredLocation to type definition & documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,28 +331,29 @@ Returns: **Promise**
 
 ## Event fields
 
-| Property                                    | Type   | Description                                                                                           | iOS | Android |
-| :------------------------------------------ | :----- | :---------------------------------------------------------------------------------------------------- | :-: | :-----: |
-| **id\***                                    | String | Unique id for the calendar event.                                                                     |  ✓  |    ✓    |
-| **calendarId\*\***                          | String | Unique id for the calendar where the event will be saved. Defaults to the device's default calendar.  |  ✓  |    ✓    |
-| **title**                                   | String | The title for the calendar event.                                                                     |  ✓  |    ✓    |
-| **startDate**                               | String | The start date of the calendar event in ISO format.                                                   |  ✓  |    ✓    |
-| **endDate**                                 | String | The end date of the calendar event in ISO format.                                                     |  ✓  |    ✓    |
-| **allDay**                                  | Bool   | Indicates whether the event is an all-day                                                             |
-| event.                                      | ✓      | ✓                                                                                                     |
-| **recurrence**                              | String | The simple recurrence frequency of the calendar event `daily`, `weekly`, `monthly`, `yearly` or none. |  ✓  |    ✓    |
-| [**recurrenceRule**](#recurrence-rule) \*\* | Object | The events recurrence settings.                                                                       |  ✓  |    ✓    |
-| **occurrenceDate\***                        | String | The original occurrence date of an event if it is part of a recurring series.                         |  ✓  |         |
-| **isDetached**                              | Bool   | Indicates whether an event is a detached instance of a repeating event.                               |  ✓  |         |
-| **url**                                     | String | The url associated with the calendar event.                                                           |  ✓  |         |
-| **location**                                | String | The location associated with the calendar event.                                                      |  ✓  |    ✓    |
-| **notes**                                   | String | The notes associated with the calendar event.                                                         |  ✓  |         |
-| **description**                             | String | The description associated with the calendar event.                                                   |     |    ✓    |
-| [**alarms**](#alarms)                       | Array  | The alarms associated with the calendar event, as an array of alarm objects.                          |  ✓  |    ✓    |
-| [**attendees**](#attendees)\*               | Array  | The attendees of the event, including the organizer.                                                  |  ✓  |    ✓    |
-| [**calendar**](#calendar)\*                 | Object | The calendar containing the event.                                                                    |  ✓  |    ✓    |
-| **skipAndroidTimezone**                     | Bool   | Skip the process of setting automatic timezone on android                                             |     |    ✓    |
-| **timeZone**                                | String | The time zone associated with the event                                                               |  ✓  |         |
+| Property                                             | Type   | Description                                                                                           | iOS | Android |
+| :--------------------------------------------------- | :----- | :---------------------------------------------------------------------------------------------------- | :-: | :-----: |
+| **id\***                                             | String | Unique id for the calendar event.                                                                     |  ✓  |    ✓    |
+| **calendarId\*\***                                   | String | Unique id for the calendar where the event will be saved. Defaults to the device's default calendar.  |  ✓  |    ✓    |
+| **title**                                            | String | The title for the calendar event.                                                                     |  ✓  |    ✓    |
+| **startDate**                                        | String | The start date of the calendar event in ISO format.                                                   |  ✓  |    ✓    |
+| **endDate**                                          | String | The end date of the calendar event in ISO format.                                                     |  ✓  |    ✓    |
+| **allDay**                                           | Bool   | Indicates whether the event is an all-day                                                             |
+| event.                                               | ✓      | ✓                                                                                                     |
+| **recurrence**                                       | String | The simple recurrence frequency of the calendar event `daily`, `weekly`, `monthly`, `yearly` or none. |  ✓  |    ✓    |
+| [**recurrenceRule**](#recurrence-rule) \*\*          | Object | The events recurrence settings.                                                                       |  ✓  |    ✓    |
+| **occurrenceDate\***                                 | String | The original occurrence date of an event if it is part of a recurring series.                         |  ✓  |         |
+| **isDetached**                                       | Bool   | Indicates whether an event is a detached instance of a repeating event.                               |  ✓  |         |
+| **url**                                              | String | The url associated with the calendar event.                                                           |  ✓  |         |
+| **location**                                         | String | The location associated with the calendar event.                                                      |  ✓  |    ✓    |
+| [**structuredLocation**](#alarm-structuredlocation)  | String | The structuredLocation associated with the calendar event.                                            |  ✓  |         |
+| **notes**                                            | String | The notes associated with the calendar event.                                                         |  ✓  |         |
+| **description**                                      | String | The description associated with the calendar event.                                                   |     |    ✓    |
+| [**alarms**](#alarms)                                | Array  | The alarms associated with the calendar event, as an array of alarm objects.                          |  ✓  |    ✓    |
+| [**attendees**](#attendees)\*                        | Array  | The attendees of the event, including the organizer.                                                  |  ✓  |    ✓    |
+| [**calendar**](#calendar)\*                          | Object | The calendar containing the event.                                                                    |  ✓  |    ✓    |
+| **skipAndroidTimezone**                              | Bool   | Skip the process of setting automatic timezone on android                                             |     |    ✓    |
+| **timeZone**                                         | String | The time zone associated with the event                                                               |  ✓  |         |
 
 ### Calendar
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -89,6 +89,8 @@ interface CalendarEventBase {
   recurrence?: RecurrenceFrequency;
   /** The location associated with the calendar event. */
   location?: string;
+  /** iOS ONLY - The location with coordinates. */
+  structuredLocation?: AlarmStructuredLocation;
   /** iOS ONLY - Indicates whether an event is a detached instance of a repeating event. */
   isDetached?: boolean;
   /** iOS ONLY - The url associated with the calendar event. */


### PR DESCRIPTION
I was looking to implement structuredLocation support for iOS, so you can create calendar events with geocoordinates. Actually this was already implemented as with #221, but the documentation and typing was missing, which I have added with this commit. 