### PR TITLE
Fixed dependency on React by changing to React-Core

### DIFF
--- a/RNCalendarEvents.podspec
+++ b/RNCalendarEvents.podspec
@@ -3,7 +3,7 @@ package = JSON.parse(File.read('./package.json'))
 
 Pod::Spec.new do |s|
   s.name         = 'RNCalendarEvents'
-  s.dependency 'React'
+  s.dependency 'React-Core'
   
   s.version         = package["version"]
   s.license         = package["license"]


### PR DESCRIPTION
This fixes the build issue on MacOS Ventura with Xcode 14. Previously, depending on React would show the error:
`Undefined symbol: _OBJC_CLASS_$_RCTConvert` when building

https://github.com/itinance/react-native-fs/issues/964

https://github.com/facebook/react-native/issues/29633#issuecomment-694187116