### PR TITLE
fix: android event reminder times

### DIFF
--- a/android/src/main/java/com/calendarevents/RNCalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/RNCalendarEvents.java
@@ -907,7 +907,7 @@ public class RNCalendarEvents extends ReactContextBaseJavaModule implements Perm
                 continue;
             }
 
-            cal.add(Calendar.MINUTE, minutes);
+            cal.add(Calendar.MINUTE, -minutes);
             alarm.putString("date", sdf.format(cal.getTime()));
             results.pushMap(alarm);
         }


### PR DESCRIPTION
- fixes bug where alarm times on android are returned with a time past the start time of the event: 
- https://github.com/wmcmahan/react-native-calendar-events/issues/330