### PR TITLE
fix(android): android gradle plugin 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,13 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.calendarevents"
+    }
+
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 


### PR DESCRIPTION
## Summary

This is the minimum required change for this module to work on react-native 0.73 which includes android gradle plugin 8

It is backwards compatible with all previous versions of react-native that include android gradle plugin 7 or even 6 and older

It is similar to changes I needed to do as react-native-firebase maintainer --> https://github.com/invertase/react-native-firebase/commit/b52d0ce6723c077190618641ce0f33ced9fd4090

## Test Plan

With apologies, you have to alter an app that integrates this module to use android gradle plugin 8 to see the error, it's difficult to do that in repos I'm proposing these changes in because bumping to android gradle plugin 8 requires a large amount of transitive dependency changes in CI

I have integrated this in an app and tested it, and done similar work as maintainer of react-native-firebase, react-native-netinfo and react-native-device-info, and I'm now pushing these out to the repos

Cheers