### PR TITLE
Fix linter errors on react native 0.74

### DIFF
--- a/android/src/main/java/com/calendarevents/RNCalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/RNCalendarEvents.java
@@ -1083,12 +1083,13 @@ public class RNCalendarEvents extends ReactContextBaseJavaModule implements Perm
             SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
 
             if (recurrenceRules.length > 0 && recurrenceRules[0].split("=").length > 1) {
-                event.putString("recurrence", recurrenceRules[0].split("=")[1].toLowerCase());
-                recurrenceRule.putString("frequency", recurrenceRules[0].split("=")[1].toLowerCase());
+                event.putString(toLowerCase("recurrence", recurrenceRules[0].split("=")[1]));
+                recurrenceRule.putString(toLowerCase("frequency", recurrenceRules[0].split("=")[1]));
             }
 
-            if (cursor.getColumnIndex(CalendarContract.Events.DURATION) != -1 && cursor.getString(cursor.getColumnIndex(CalendarContract.Events.DURATION)) != null) {
-                recurrenceRule.putString("duration", cursor.getString(cursor.getColumnIndex(CalendarContract.Events.DURATION)));
+            int durationIndex = cursor.getColumnIndex(CalendarContract.Events.DURATION);
+            if (durationIndex != -1 && cursor.getString(durationIndex) != null) {
+                recurrenceRule.putString("duration", cursor.getString(durationIndex));
             }
 
             if (recurrenceRules.length >= 2 && recurrenceRules[1].split("=")[0].equals("INTERVAL")) {
@@ -1129,12 +1130,14 @@ public class RNCalendarEvents extends ReactContextBaseJavaModule implements Perm
             event.putArray("alarms", emptyAlarms);
         }
 
-        if (cursor.getColumnIndex(CalendarContract.Events.ORIGINAL_ID) != -1 && cursor.getString(cursor.getColumnIndex(CalendarContract.Events.ORIGINAL_ID)) != null) {
-            event.putString("originalId", cursor.getString(cursor.getColumnIndex(CalendarContract.Events.ORIGINAL_ID)));
+        int originalIdIndex = cursor.getColumnIndex(CalendarContract.Events.ORIGINAL_ID);
+        if (originalIdIndex != -1 && cursor.getString(originalIdIndex) != null) {
+            event.putString("originalId", cursor.getString(originalIdIndex));
         }
 
-        if (cursor.getColumnIndex(CalendarContract.Instances.ORIGINAL_SYNC_ID) != -1 && cursor.getString(cursor.getColumnIndex(CalendarContract.Instances.ORIGINAL_SYNC_ID)) != null) {
-            event.putString("syncId", cursor.getString(cursor.getColumnIndex(CalendarContract.Instances.ORIGINAL_SYNC_ID)));
+        int originalSyncIdIndex = cursor.getColumnIndex(CalendarContract.Instances.ORIGINAL_SYNC_ID);
+        if (originalSyncIdIndex != -1 && cursor.getString(originalSyncIdIndex) != null) {
+            event.putString("syncId", cursor.getString(originalSyncIdIndex));
         }
 
         return event;

--- a/android/src/main/java/com/calendarevents/RNCalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/RNCalendarEvents.java
@@ -1083,8 +1083,8 @@ public class RNCalendarEvents extends ReactContextBaseJavaModule implements Perm
             SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
 
             if (recurrenceRules.length > 0 && recurrenceRules[0].split("=").length > 1) {
-                event.putString(toLowerCase("recurrence", recurrenceRules[0].split("=")[1]));
-                recurrenceRule.putString(toLowerCase("frequency", recurrenceRules[0].split("=")[1]));
+                event.putString("recurrence", recurrenceRules[0].split("=")[1].toLowerCase());
+                recurrenceRule.putString("frequency", recurrenceRules[0].split("=")[1].toLowerCase());
             }
 
             int durationIndex = cursor.getColumnIndex(CalendarContract.Events.DURATION);

--- a/android/src/main/java/com/calendarevents/RNCalendarEvents.java
+++ b/android/src/main/java/com/calendarevents/RNCalendarEvents.java
@@ -1113,8 +1113,20 @@ public class RNCalendarEvents extends ReactContextBaseJavaModule implements Perm
         }
 
         event.putString("id", cursor.getString(0));
-        event.putMap("calendar", findCalendarById(cursor.getString(cursor.getColumnIndex("calendar_id"))));
-        event.putString("title", cursor.getString(cursor.getColumnIndex("title")));
+        int calendarIdIndex = cursor.getColumnIndex("calendar_id");
+        if (calendarIdIndex != -1) {
+            String calendarId = cursor.getString(calendarIdIndex);
+            if (calendarId != null) {
+                event.putMap("calendar", findCalendarById(calendarId));
+            }
+        }
+        int titleIndex = cursor.getColumnIndex("title");
+        if (titleIndex != -1) {
+            String title = cursor.getString(titleIndex);
+            if (title != null) {
+                event.putString("title", title);
+            }
+        }
         event.putString("description", cursor.getString(2));
         event.putString("startDate", startDateUTC);
         event.putString("endDate", endDateUTC);


### PR DESCRIPTION
Removes this error:
```
/Users/xxx/Documents/GitHub/xxx/node_modules/react-native-calendar-events/android/src/main
/java/com/calendarevents/RNCalendarEvents.java:1090: Error: Value must be ≥ 0 but getColumnIndex can be -1 [Ra
nge]
            if (cursor.getColumnIndex(CalendarContract.Events.DURATION) != -1 && cursor.getString(cursor.getCo
lumnIndex(CalendarContract.Events.DURATION)) != null) {
```